### PR TITLE
Added back the old .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock


### PR DESCRIPTION
When the new "tockloader-rs" repository was made, it seems that the ".gitignore" file was not transferred over.
In this pull request I have added it back.